### PR TITLE
css and js minify and path reference, file loading within body

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,61 @@ gulp.task('default', function () {
 ...
 ```
 
+## Extended example
+
+### `index.html`
+
+```html
+<html>
+	<head>
+		<!-- smoosh -->
+		<link rel='stylesheet' href='styles.css'>
+		<!-- endsmoosh -->
+	</head>
+	<body>
+		<!-- smoosh -->
+		<smoosh data="file.txt"> </smoosh>
+		<!-- endsmoosh -->
+...
+```
+
+### `styles.css`
+
+```css
+body {
+	background: red;
+}
+```
+### `file.txt`
+```text
+Hello World!
+```
+
+### `Gulpfile.js`
+
+```js
+var gulp = require('gulp');
+var smoosher = require('gulp-smoosher');
+
+gulp.task('default', function () {
+	gulp.src('index.html')
+		.pipe(smoosher({"minify":true,"pathtag":true}))
+		.pipe(gulp.dest('dist'));
+});
+```
+
+### `dist/index.html`
+
+```html
+<html>
+	<head>
+		<style smoosh="styles.css">body{background:red;}</style>
+	</head>
+	<body>
+	Hello World!
+...
+```
+
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "gulp-util": "~2.2.14",
     "through2": "~0.4.1",
     "cheerio": "~0.13.1",
-    "gulp-replace": "~0.2.0"
+    "gulp-replace": "~0.2.0",
+    "uglify-js": "~2.4.12",
+    "clean-css": "~2.0.8"
   },
   "devDependencies": {
     "mocha": "~1.17.1"


### PR DESCRIPTION
Added options to minify/uglify js and css and to write the path reference to the output tag.
Load/replace content within the DOM by using a „smoosh“-element. The
data-attribute provides the source-file to be added.
Changes are just roughly tested!
