### PR TITLE
add proper support for <link rel="import">

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,13 @@ module.exports = function() {
 				$('link').each(function(index, element) {
 					var href = $(element).attr('href');
 					if (isLocal(href)) {
-						$(element).replaceWith('<style>' + fs.readFileSync(path.join(file.base, href), 'utf8') + '</style>');
+						var rel = $(element).attr('rel');
+						if (rel == 'import')
+							$(element).replaceWith(fs.readFileSync(path.join(file.base, href), 'utf8'));
+
+						else
+							$(element).replaceWith('<style>' + fs.readFileSync(path.join(file.base, href), 'utf8') + '</style>');
+
 					}
 				});
 

--- a/test/fixtures/input.html
+++ b/test/fixtures/input.html
@@ -1,6 +1,9 @@
 <!-- smoosh -->
 <link rel='stylesheet' href='one.css'>
 <!-- endsmoosh -->
+<!-- smoosh -->
+<link rel='import' href='one.js'>
+<!-- endsmoosh -->
 <link rel='stylesheet' href='two.css'>
 <script src='two.js'>
 <!-- smoosh -->

--- a/test/fixtures/output.html
+++ b/test/fixtures/output.html
@@ -1,4 +1,5 @@
 <style>/* one.css */</style>
+/* one.js */
 <link rel='stylesheet' href='two.css'>
 <script src='two.js'>
 <script>/* one.js */</script>


### PR DESCRIPTION
Web Components can be imported using <link rel="import">, but the
results shouldn't be wrapped in <style/>.

This commit looks at the rel attribute and prevents the wrap if it is "import".
Includes unit test modifications.

---

Another option would be to only do the <style> wrapping if rel="stylesheet", but I figured that was more intrusive to the existing plugin. 
